### PR TITLE
Added ament_lint_auto dependency

### DIFF
--- a/udp_driver/package.xml
+++ b/udp_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>udp_driver</name>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <description>A template class and associated utilities which encapsulate basic reading from UDP sockets</description>
     <maintainer email="opensource@apex.ai">Apex.AI, Inc.</maintainer>
     <license>Apache License 2.0</license>
@@ -14,6 +14,7 @@
     <depend>rclcpp</depend>
     <depend>std_msgs</depend>
 
+    <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>
     <test_depend>ament_cmake_gtest</test_depend>
 


### PR DESCRIPTION
This fixes the error in http://build.ros2.org/job/Dbin_ubv8_uBv8__udp_driver__ubuntu_bionic_arm64__binary/3/ and also bumps the version so we can make a new release.