### PR TITLE
Be specific about which parts of Boost are necessary

### DIFF
--- a/serial_driver/package.xml
+++ b/serial_driver/package.xml
@@ -10,11 +10,15 @@
     <buildtool_depend>ament_cmake</buildtool_depend>
     <buildtool_depend>autoware_auto_cmake</buildtool_depend>
 
+    <build_depend>libboost-system-dev</build_depend>
+    <build_export_depend>libboost-system-dev</build_export_depend>
+
     <depend>autoware_auto_helper_functions</depend>
-    <depend>boost</depend>
     <depend>rclcpp_lifecycle</depend>
     <depend>rclcpp</depend>
     <depend>std_msgs</depend>
+
+    <exec_depend>libboost-system</exec_depend>
 
     <test_depend>ament_cmake_gtest</test_depend>
     <test_depend>ament_lint_auto</test_depend>

--- a/udp_driver/package.xml
+++ b/udp_driver/package.xml
@@ -9,10 +9,14 @@
 
     <buildtool_depend>ament_cmake</buildtool_depend>
 
-    <depend>boost</depend>
+    <build_depend>libboost-system-dev</build_depend>
+    <build_export_depend>libboost-system-dev</build_export_depend>
+
     <depend>rclcpp_lifecycle</depend>
     <depend>rclcpp</depend>
     <depend>std_msgs</depend>
+
+    <exec_depend>libboost-system</exec_depend>
 
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
In the spirit of [Generating 'dev' and runtime artefacts from ROS packages](https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448) on ROS Discourse this PR attempts to split the build and run dependencies for Boost for both the `serial` and `udp` packages.

CI will most likely fail until https://github.com/ros/rosdistro/pull/23624 gets merged.

I've based the dependencies on what is `find_package(..)`d in the `CMakeLists.txt`.
