### PR TITLE
Remove Autoware.AUTO Dependencies

### DIFF
--- a/serial_driver/CMakeLists.txt
+++ b/serial_driver/CMakeLists.txt
@@ -23,12 +23,8 @@ find_package(Boost REQUIRED COMPONENTS system)
 
 ament_auto_find_build_dependencies()
 
-if(Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-  link_directories(${Boost_LIBRARY_DIRS})
-endif()
-
-include_directories(include)
+include_directories(include ${Boost_INCLUDE_DIRS})
+link_directories(${Boost_LIBRARY_DIRS})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto)

--- a/serial_driver/CMakeLists.txt
+++ b/serial_driver/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Copyright 2018 Apex.AI, Inc.
-# Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,50 +11,45 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 cmake_minimum_required(VERSION 3.5)
 
 project(serial_driver)
 
 ## dependencies
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(autoware_auto_cmake REQUIRED)
-find_package(autoware_auto_helper_functions REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
+
+ament_auto_find_build_dependencies()
+
 if(Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS})
-    link_directories(${Boost_LIBRARY_DIRS})
+  include_directories(${Boost_INCLUDE_DIRS})
+  link_directories(${Boost_LIBRARY_DIRS})
 endif()
 
 include_directories(include)
 
-ament_export_dependencies("autoware_auto_helper_functions")
-autoware_install(HAS_INCLUDE)
-
 if(BUILD_TESTING)
-    find_package(std_msgs REQUIRED)
-    set(TEST_LIB "${PROJECT_NAME}_test")
-    add_library(${TEST_LIB} SHARED test/test_driver.hpp test/test_driver.cpp)
+  find_package(ament_lint_auto)
+  ament_lint_auto_find_test_dependencies()
 
-    ament_target_dependencies(${TEST_LIB} "autoware_auto_helper_functions" "rclcpp" "rclcpp_lifecycle" "std_msgs")
-    target_include_directories(${TEST_LIB} PRIVATE include)
-    target_link_libraries(${TEST_LIB} ${Boost_LIBRARIES})
+  set(TEST_LIB "${PROJECT_NAME}_test")
+  add_library(${TEST_LIB} SHARED test/test_driver.hpp test/test_driver.cpp)
+  ament_target_dependencies(${TEST_LIB} "rclcpp" "rclcpp_lifecycle" "std_msgs")
+  target_include_directories(${TEST_LIB} PRIVATE include)
+  target_link_libraries(${TEST_LIB} ${Boost_LIBRARIES})
 
-    # Unit tests
-    find_package(ament_cmake_gtest REQUIRED)
-    set(TEST_SERIAL_DRIVER_EXE test_serial_driver)
-    ament_add_gtest(${TEST_SERIAL_DRIVER_EXE}
-            test/gtest_main.cpp
-            test/test_serial_driver.cpp)
-    ament_target_dependencies(${TEST_SERIAL_DRIVER_EXE}  "Boost")
-    target_include_directories(${TEST_SERIAL_DRIVER_EXE} PRIVATE include)
-    target_link_libraries(${TEST_SERIAL_DRIVER_EXE} ${TEST_LIB} util)
-
-    autoware_static_code_analysis()
+  # Unit tests
+  set(TEST_SERIAL_DRIVER_EXE test_serial_driver)
+  ament_add_gtest(${TEST_SERIAL_DRIVER_EXE}
+    test/gtest_main.cpp
+    test/test_serial_driver.cpp)
+  ament_target_dependencies(${TEST_SERIAL_DRIVER_EXE}  "Boost")
+  target_include_directories(${TEST_SERIAL_DRIVER_EXE} PRIVATE include)
+  target_link_libraries(${TEST_SERIAL_DRIVER_EXE} ${TEST_LIB} util)
 endif()
 
-ament_package(
-    CONFIG_EXTRAS_POST "serial_driver-extras.cmake"
+ament_auto_package(
+  CONFIG_EXTRAS_POST "serial_driver-extras.cmake"
 )

--- a/serial_driver/include/serial_driver/serial_driver_node.hpp
+++ b/serial_driver/include/serial_driver/serial_driver_node.hpp
@@ -59,6 +59,7 @@ enum class stop_bits_t
   two
 };
 
+// TODO(JWhitleyWork): Move to separate package at a later date.
 template<typename Derived>
 class crtp
 {

--- a/serial_driver/include/serial_driver/serial_driver_node.hpp
+++ b/serial_driver/include/serial_driver/serial_driver_node.hpp
@@ -1,5 +1,4 @@
 // Copyright 2018 Apex.AI, Inc.
-// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 
 
 /// \copyright Copyright 2018 Apex.AI, Inc.
@@ -23,7 +24,6 @@
 #include <chrono>
 #include <memory>
 #include <string>
-#include "helper_functions/crtp.hpp"
 #include "boost/asio.hpp"
 #include "boost/array.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -59,12 +59,33 @@ enum class stop_bits_t
   two
 };
 
+template<typename Derived>
+class crtp
+{
+protected:
+  const Derived & impl() const
+  {
+    // This is the CRTP pattern for static polymorphism: this is related, static_cast is the only
+    // way to do this
+    //lint -e{9005, 9176, 1939} NOLINT
+    return *static_cast<const Derived *>(this);
+  }
+
+  Derived & impl()
+  {
+    // This is the CRTP pattern for static polymorphism: this is related, static_cast is the only
+    // way to do this
+    //lint -e{9005, 9176, 1939} NOLINT
+    return *static_cast<Derived *>(this);
+  }
+};
+
 /// \brief A node which encapsulates the primary functionality of a serial port receiver
 /// \tparam PacketT The type of the packet buffer. Typically a container
 /// \tparam OutputT The type a packet gets converted/deserialized into. Should be a ROS 2 message
 template<typename Derived, typename PacketT, typename OutputT>
 class SerialDriverNode : public rclcpp_lifecycle::LifecycleNode,
-  public autoware::common::helper_functions::crtp<Derived>
+  public crtp<Derived>
 {
 public:
   class SerialPortConfig

--- a/serial_driver/include/serial_driver/visibility_control.hpp
+++ b/serial_driver/include/serial_driver/visibility_control.hpp
@@ -1,5 +1,4 @@
 // Copyright 2018 Apex.AI, Inc.
-// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 
 #ifndef SERIAL_DRIVER__VISIBILITY_CONTROL_HPP_
 #define SERIAL_DRIVER__VISIBILITY_CONTROL_HPP_

--- a/serial_driver/package.xml
+++ b/serial_driver/package.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
-    <name>serial_driver</name>
-    <version>0.0.4</version>
-    <description>A template class and associated utilities which encapsulate basic reading from serial ports</description>
-    <maintainer email="opensource@apex.ai">Apex.AI, Inc.</maintainer>
-    <license>Apache License 2.0</license>
+  <name>serial_driver</name>
+  <version>0.0.4</version>
+  <description>A template class and associated utilities which encapsulate basic reading from serial ports</description>
+  <maintainer email="opensource@apex.ai">Apex.AI, Inc.</maintainer>
+  <license>Apache License 2.0</license>
 
-    <buildtool_depend>ament_cmake</buildtool_depend>
-    <buildtool_depend>autoware_auto_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-    <build_depend>libboost-system-dev</build_depend>
-    <build_export_depend>libboost-system-dev</build_export_depend>
+  <build_depend>libboost-system-dev</build_depend>
+  <build_export_depend>libboost-system-dev</build_export_depend>
 
-    <depend>autoware_auto_helper_functions</depend>
-    <depend>rclcpp_lifecycle</depend>
-    <depend>rclcpp</depend>
-    <depend>std_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>std_msgs</depend>
 
-    <exec_depend>libboost-system</exec_depend>
+  <exec_depend>libboost-system</exec_depend>
 
-    <test_depend>ament_cmake_gtest</test_depend>
-    <test_depend>ament_lint_auto</test_depend>
-    <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
 
-    <export><build_type>ament_cmake</build_type></export>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/serial_driver/serial_driver-extras.cmake
+++ b/serial_driver/serial_driver-extras.cmake
@@ -1,5 +1,4 @@
 # Copyright 2018 Apex.AI, Inc.
-# Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 
 find_package(Boost REQUIRED COMPONENTS system)
 list(APPEND serial_driver_LIBRARIES ${Boost_LIBRARIES})

--- a/serial_driver/test/gtest_main.cpp
+++ b/serial_driver/test/gtest_main.cpp
@@ -1,5 +1,4 @@
 // Copyright 2018 Apex.AI, Inc.
-// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 
 #include "gtest/gtest.h"
 

--- a/serial_driver/test/test_driver.cpp
+++ b/serial_driver/test/test_driver.cpp
@@ -1,5 +1,4 @@
 // Copyright 2018 Apex.AI, Inc.
-// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 
 #include "test_driver.hpp"
 
+#include <string>
+
 namespace test_serial_driver
 {
-    Packet::Packet(int32_t val): value(val) {}
-    Packet::Packet(): value(0) {}
+
+Packet::Packet(int32_t val)
+: value(val) {}
+Packet::Packet()
+: value(0) {}
 
 TestDriver::TestDriver(
   const std::string & node_name,

--- a/serial_driver/test/test_driver.hpp
+++ b/serial_driver/test/test_driver.hpp
@@ -1,5 +1,4 @@
 // Copyright 2018 Apex.AI, Inc.
-// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 
-#ifndef TEST_SERIAL_DRIVER_HPP_
-#define TEST_SERIAL_DRIVER_HPP_
-#include <std_msgs/msg/int32.hpp>
-#include "serial_driver/serial_driver_node.hpp"
+#ifndef TEST_DRIVER_HPP_
+#define TEST_DRIVER_HPP_
+
+#include <serial_driver/serial_driver_node.hpp>
 #include <serial_driver/visibility_control.hpp>
-// double quotes here for static analysis
+
+#include <std_msgs/msg/int32.hpp>
+
+#include <string>
 
 namespace test_serial_driver
 {
@@ -26,17 +30,19 @@ namespace test_serial_driver
 class SERIAL_DRIVER_PUBLIC Packet
 {
 public:
-    Packet(int32_t val);
-    Packet();
-      int32_t value;
+  explicit Packet(int32_t val);
+  Packet();
+  int32_t value;
 };
 
 
 using autoware::drivers::serial_driver::flow_control_t;
 using autoware::drivers::serial_driver::parity_t;
 using autoware::drivers::serial_driver::stop_bits_t;
+using autoware::drivers::serial_driver::SerialDriverNode;
 
-class SERIAL_DRIVER_PUBLIC TestDriver : public autoware::drivers::serial_driver::SerialDriverNode<TestDriver, Packet, std_msgs::msg::Int32>
+class SERIAL_DRIVER_PUBLIC TestDriver
+  : public SerialDriverNode<TestDriver, Packet, std_msgs::msg::Int32>
 {
 public:
   TestDriver(
@@ -60,7 +66,7 @@ private:
   int32_t m_times_init_output_has_been_called;
 };  // class TestDriver
 
-using TestDriverT = autoware::drivers::serial_driver::SerialDriverNode<TestDriver, Packet, std_msgs::msg::Int32>;
+using TestDriverT = SerialDriverNode<TestDriver, Packet, std_msgs::msg::Int32>;
 
 }  // namespace test_serial_driver
-#endif  // TEST_SERIAL_DRIVER_HPP_
+#endif  // TEST_DRIVER_HPP_

--- a/serial_driver/test/test_serial_driver.cpp
+++ b/serial_driver/test/test_serial_driver.cpp
@@ -1,5 +1,4 @@
 // Copyright 2018 Apex.AI, Inc.
-// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
+
+#include "test_driver.hpp"
+
+#include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
-#include "test_driver.hpp"
 
 #if defined(__linux__)
 #include <pty.h>
@@ -34,15 +39,16 @@ namespace
 class serial_driver : public ::testing::Test
 {
 protected:
-  virtual void SetUp() {
+  virtual void SetUp()
+  {
     if (openpty(&master_fd, &slave_fd, name, NULL, NULL) == -1) {
       perror("openpty");
       exit(127);
     }
 
-    ASSERT_TRUE(master_fd > 0);
-    ASSERT_TRUE(slave_fd > 0);
-    ASSERT_TRUE(std::string(name).length() > 0);
+    ASSERT_GT(master_fd, 0);
+    ASSERT_GT(slave_fd, 0);
+    ASSERT_GT(std::string(name).length(), 0);
   }
 
   int master_fd;
@@ -52,22 +58,22 @@ protected:
 }  // namespace
 
 
-//tests serial_driver_node's get_packet function which receives serial packages
+// tests serial_driver_node's get_packet function which receives serial packages
 TEST_F(serial_driver, basic)
 {
-  //rclcpp::init required to start the node
+  // rclcpp::init required to start the node
   rclcpp::init(0, nullptr);
 
-  //setting values to send
+  // setting values to send
   std::vector<int32_t> values(10);
-  std::generate(values.begin(), values.end(), [n = 0] () mutable { return n++; });
+  std::generate(values.begin(), values.end(), [n = 0]() mutable {return n++;});
 
   TestDriver driver(
     "serial_driver_node",
     "serial_topic",
     name,
     TestDriver::SerialPortConfig {38400, flow_control_t::software, parity_t::even, stop_bits_t::one}
-    );
+  );
 
   for (auto val : values) {
     write(master_fd, reinterpret_cast<char *>(&val), sizeof(val));


### PR DESCRIPTION
Since Autoware.AUTO is no longer in the build farm, these changes are necessary to remove dependencies on Autoware.AUTO-specific packages.