### PR TITLE
Remove lifecycle references

### DIFF
--- a/serial_driver/CMakeLists.txt
+++ b/serial_driver/CMakeLists.txt
@@ -32,7 +32,7 @@ if(BUILD_TESTING)
 
   set(TEST_LIB "${PROJECT_NAME}_test")
   add_library(${TEST_LIB} SHARED test/test_driver.hpp test/test_driver.cpp)
-  ament_target_dependencies(${TEST_LIB} "rclcpp" "rclcpp_lifecycle" "std_msgs")
+  ament_target_dependencies(${TEST_LIB} "rclcpp" "std_msgs")
   target_include_directories(${TEST_LIB} PRIVATE include)
   target_link_libraries(${TEST_LIB} ${Boost_LIBRARIES})
 

--- a/serial_driver/include/serial_driver/serial_driver_node.hpp
+++ b/serial_driver/include/serial_driver/serial_driver_node.hpp
@@ -27,7 +27,6 @@
 #include "boost/asio.hpp"
 #include "boost/array.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 namespace autoware
 {
@@ -85,7 +84,7 @@ protected:
 /// \tparam PacketT The type of the packet buffer. Typically a container
 /// \tparam OutputT The type a packet gets converted/deserialized into. Should be a ROS 2 message
 template<typename Derived, typename PacketT, typename OutputT>
-class SerialDriverNode : public rclcpp_lifecycle::LifecycleNode,
+class SerialDriverNode : public rclcpp::Node,
   public crtp<Derived>
 {
 public:
@@ -148,7 +147,7 @@ private:
     const std::string & device_name,
     const SerialPortConfig & serial_port_config,
     size_t history_depth = 10)
-  : LifecycleNode(node_name),
+  : Node(node_name),
     m_pub_ptr(this->create_publisher<OutputT>(topic, rclcpp::QoS(history_depth))),
     m_io_service(),
     m_serial_port(m_io_service)
@@ -166,11 +165,11 @@ private:
     const std::string & node_name,
     const std::string & node_namespace,
     size_t history_depth = 10)
-  : LifecycleNode(
+  : Node(
       node_name,
       node_namespace),
     m_pub_ptr(
-      LifecycleNode::create_publisher<OutputT>(declare_parameter("topic").get<std::string>(),
+      Node::create_publisher<OutputT>(declare_parameter("topic").get<std::string>(),
       rclcpp::QoS(history_depth))),
     m_io_service(),
     m_serial_port(m_io_service)
@@ -226,8 +225,6 @@ private:
     // initialize the output object
     OutputT output;
     this->impl().init_output(output);
-    // activate the publisher
-    m_pub_ptr->on_activate();
 
     uint32_t iter = 0U;
     // workaround for rclcpp logging macros with template class
@@ -344,7 +341,7 @@ private:
     }
   }
 
-  const std::shared_ptr<typename rclcpp_lifecycle::LifecyclePublisher<OutputT>> m_pub_ptr;
+  const std::shared_ptr<typename rclcpp::Publisher<OutputT>> m_pub_ptr;
   boost::asio::io_service m_io_service;
   boost::asio::serial_port m_serial_port;
 };  // class SerialDriverNode

--- a/serial_driver/package.xml
+++ b/serial_driver/package.xml
@@ -12,7 +12,6 @@
   <depend>libboost-dev</depend>
   <depend>libboost-system-dev</depend>
   <depend>rclcpp</depend>
-  <depend>rclcpp_lifecycle</depend>
   <depend>std_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/udp_driver/CMakeLists.txt
+++ b/udp_driver/CMakeLists.txt
@@ -19,7 +19,6 @@ project(udp_driver)
 ## dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 if(Boost_FOUND)
@@ -40,7 +39,7 @@ if(BUILD_TESTING)
     set(TEST_LIB "${PROJECT_NAME}_test")
     add_library(${TEST_LIB} SHARED test/test_driver.hpp test/test_driver.cpp)
 
-    ament_target_dependencies(${TEST_LIB} "rclcpp" "rclcpp_lifecycle" "std_msgs")
+    ament_target_dependencies(${TEST_LIB} "rclcpp" "std_msgs")
     target_include_directories(${TEST_LIB} PRIVATE include)
     target_link_libraries(${TEST_LIB} ${Boost_LIBRARIES})
 

--- a/udp_driver/include/udp_driver/udp_driver_node.hpp
+++ b/udp_driver/include/udp_driver/udp_driver_node.hpp
@@ -25,7 +25,6 @@
 #include "boost/asio.hpp"
 #include "boost/array.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
 
 namespace autoware
 {
@@ -39,7 +38,7 @@ namespace udp_driver
 /// \tparam PacketT The type of the packet buffer. Typically a container
 /// \tparam OutputT The type a packet gets converted/deserialized into. Should be a ROS 2 message
 template<typename PacketT, typename OutputT>
-class UdpDriverNode : public rclcpp_lifecycle::LifecycleNode
+class UdpDriverNode : public rclcpp::Node
 {
 public:
   class UdpConfig
@@ -73,7 +72,7 @@ private:
     const std::string & node_name,
     const std::string & topic,
     const UdpConfig & udp_config)
-  : LifecycleNode(node_name),
+  : Node(node_name),
     m_pub_ptr(this->create_publisher<OutputT>(topic, rclcpp::QoS(10))),
     m_io_service(),
     m_udp_socket(m_io_service,
@@ -86,11 +85,11 @@ private:
   UdpDriverNode(
     const std::string & node_name,
     const std::string & node_namespace)
-  : LifecycleNode(
+  : Node(
       node_name,
       node_namespace),
     m_pub_ptr(
-      LifecycleNode::create_publisher<OutputT>(declare_parameter("topic").get<std::string>(),
+      Node::create_publisher<OutputT>(declare_parameter("topic").get<std::string>(),
       rclcpp::QoS(10))),
     m_io_service(),
     m_udp_socket(m_io_service, boost::asio::ip::udp::endpoint(
@@ -104,8 +103,6 @@ private:
     // initialize the output object
     OutputT output;
     init_output(output);
-    // activate the publisher
-    m_pub_ptr->on_activate();
 
     uint32_t iter = 0U;
     // workaround for rclcpp logging macros with template class
@@ -174,7 +171,7 @@ private:
     return len;
   }
 
-  const std::shared_ptr<typename rclcpp_lifecycle::LifecyclePublisher<OutputT>> m_pub_ptr;
+  const std::shared_ptr<typename rclcpp::Publisher<OutputT>> m_pub_ptr;
   boost::asio::io_service m_io_service;
   boost::asio::ip::udp::socket m_udp_socket;
 };  // class UdpDriverNode

--- a/udp_driver/package.xml
+++ b/udp_driver/package.xml
@@ -11,7 +11,6 @@
 
     <depend>libboost-dev</depend>
     <depend>libboost-system-dev</depend>
-    <depend>rclcpp_lifecycle</depend>
     <depend>rclcpp</depend>
     <depend>std_msgs</depend>
 


### PR DESCRIPTION
Following the discussion about removing lifecycle nodes in Autoware.Auto, here are the corresponding changes.