### PR TITLE
remove autoware namespace

### DIFF
--- a/serial_driver/include/serial_driver/serial_driver_node.hpp
+++ b/serial_driver/include/serial_driver/serial_driver_node.hpp
@@ -28,8 +28,6 @@
 #include "boost/array.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-namespace autoware
-{
 namespace drivers
 {
 /// \brief A template class and associated utilities which encapsulate basic reading from a serial
@@ -348,6 +346,5 @@ private:
 };  // class SerialDriverNode
 }  // namespace serial_driver
 }  // namespace drivers
-}  // namespace autoware
 
 #endif  // SERIAL_DRIVER__SERIAL_DRIVER_NODE_HPP_

--- a/serial_driver/test/test_driver.hpp
+++ b/serial_driver/test/test_driver.hpp
@@ -36,10 +36,10 @@ public:
 };
 
 
-using autoware::drivers::serial_driver::flow_control_t;
-using autoware::drivers::serial_driver::parity_t;
-using autoware::drivers::serial_driver::stop_bits_t;
-using autoware::drivers::serial_driver::SerialDriverNode;
+using drivers::serial_driver::flow_control_t;
+using drivers::serial_driver::parity_t;
+using drivers::serial_driver::stop_bits_t;
+using drivers::serial_driver::SerialDriverNode;
 
 class SERIAL_DRIVER_PUBLIC TestDriver
   : public SerialDriverNode<TestDriver, Packet, std_msgs::msg::Int32>

--- a/udp_driver/examples/udp_driver_node.cpp
+++ b/udp_driver/examples/udp_driver_node.cpp
@@ -77,7 +77,7 @@ void UdpDriverNode::receiver_callback(const MutSocketBuffer & buffer)
     *reinterpret_cast<int32_t *>(buffer.data()) << std::endl;
 
   std_msgs::msg::Int32 out;
-  msgs::convertToRos2Message(buffer, out);
+  utils::convertToRos2Message(buffer, out);
 
   m_publisher->publish(out);
 }
@@ -88,7 +88,7 @@ void UdpDriverNode::subscriber_callback(std_msgs::msg::Int32::SharedPtr msg)
     msg->data << std::endl;
 
   MutSocketBuffer out;
-  msgs::convertFromRos2Message(msg, out);
+  utils::convertFromRos2Message(msg, out);
 
   m_udp_driver->sender()->asyncSend(out);
 }

--- a/udp_driver/examples/udp_driver_node.cpp
+++ b/udp_driver/examples/udp_driver_node.cpp
@@ -18,8 +18,6 @@
 
 #include "udp_driver_node.hpp"
 
-namespace autoware
-{
 namespace drivers
 {
 
@@ -79,7 +77,7 @@ void UdpDriverNode::receiver_callback(const MutSocketBuffer & buffer)
     *reinterpret_cast<int32_t *>(buffer.data()) << std::endl;
 
   std_msgs::msg::Int32 out;
-  autoware::msgs::convertToRos2Message(buffer, out);
+  msgs::convertToRos2Message(buffer, out);
 
   m_publisher->publish(out);
 }
@@ -90,10 +88,9 @@ void UdpDriverNode::subscriber_callback(std_msgs::msg::Int32::SharedPtr msg)
     msg->data << std::endl;
 
   MutSocketBuffer out;
-  autoware::msgs::convertFromRos2Message(msg, out);
+  msgs::convertFromRos2Message(msg, out);
 
   m_udp_driver->sender()->asyncSend(out);
 }
 
 }  // namespace drivers
-}  // namespace autoware

--- a/udp_driver/examples/udp_driver_node.hpp
+++ b/udp_driver/examples/udp_driver_node.hpp
@@ -27,10 +27,8 @@
 #include "msg_converters/converters.hpp"
 #include "udp_driver/udp_driver.hpp"
 
-using autoware::drivers::UdpSocket;
+using drivers::UdpSocket;
 
-namespace autoware
-{
 namespace drivers
 {
 
@@ -59,6 +57,5 @@ private:
 };  // class UdpDriverNode
 
 }  // namespace drivers
-}  // namespace autoware
 
 #endif  // UDP_DRIVER__EXAMPLES__UDP_DRIVER_NODE_HPP_

--- a/udp_driver/include/io_context/io_context.hpp
+++ b/udp_driver/include/io_context/io_context.hpp
@@ -23,9 +23,6 @@
 
 #include <memory>
 
-namespace autoware
-{
-
 namespace drivers
 {
 
@@ -55,6 +52,5 @@ private:
 };
 
 }  // namespace drivers
-}  // namespace autoware
 
 #endif  // IO_CONTEXT__IO_CONTEXT_HPP_

--- a/udp_driver/include/msg_converters/std_msgs.hpp
+++ b/udp_driver/include/msg_converters/std_msgs.hpp
@@ -41,8 +41,6 @@
 
 #include "common.hpp"
 
-namespace autoware
-{
 namespace msgs
 {
 
@@ -97,6 +95,5 @@ void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float32 & o
 void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float64 & out);
 
 }  // namespace msgs
-}  // namespace autoware
 
 #endif  // MSG_CONVERTERS__STD_MSGS_HPP_

--- a/udp_driver/include/msg_converters/std_msgs.hpp
+++ b/udp_driver/include/msg_converters/std_msgs.hpp
@@ -41,7 +41,9 @@
 
 #include "common.hpp"
 
-namespace msgs
+namespace drivers
+{
+namespace utils
 {
 
 /*
@@ -94,6 +96,7 @@ void convertFromRos2Message(const std_msgs::msg::Float64::SharedPtr & in, MutSoc
 void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float32 & out);
 void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float64 & out);
 
-}  // namespace msgs
+}  // namespace utils
+}  // namespace drivers
 
 #endif  // MSG_CONVERTERS__STD_MSGS_HPP_

--- a/udp_driver/include/udp_driver/udp_driver.hpp
+++ b/udp_driver/include/udp_driver/udp_driver.hpp
@@ -24,8 +24,6 @@
 #include "io_context/io_context.hpp"
 #include "udp_socket.hpp"
 
-namespace autoware
-{
 namespace drivers
 {
 
@@ -48,6 +46,5 @@ private:
 };
 
 }  // namespace drivers
-}  // namespace autoware
 
 #endif  // UDP_DRIVER__UDP_DRIVER_HPP_

--- a/udp_driver/include/udp_driver/udp_socket.hpp
+++ b/udp_driver/include/udp_driver/udp_socket.hpp
@@ -27,8 +27,6 @@
 using boost::asio::ip::udp;
 using boost::asio::ip::address;
 
-namespace autoware
-{
 namespace drivers
 {
 
@@ -87,6 +85,5 @@ private:
 };
 
 }  // namespace drivers
-}  // namespace autoware
 
 #endif  // UDP_DRIVER__UDP_SOCKET_HPP_

--- a/udp_driver/src/io_context.cpp
+++ b/udp_driver/src/io_context.cpp
@@ -18,8 +18,6 @@
 
 #include <iostream>
 
-namespace autoware
-{
 namespace drivers
 {
 
@@ -73,4 +71,3 @@ void IoContext::waitForExit()
 }
 
 }  // namespace drivers
-}  // namespace autoware

--- a/udp_driver/src/msg_converters/std_msgs.cpp
+++ b/udp_driver/src/msg_converters/std_msgs.cpp
@@ -17,7 +17,9 @@
 #include "msg_converters/std_msgs.hpp"
 
 
-namespace msgs
+namespace drivers
+{
+namespace utils
 {
 
 /*
@@ -144,4 +146,5 @@ void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float64 & o
   out.data = *boost::asio::buffer_cast<double_t *>(in);
 }
 
-}  // namespace msgs
+}  // namespace utils
+}  // namespace drivers

--- a/udp_driver/src/msg_converters/std_msgs.cpp
+++ b/udp_driver/src/msg_converters/std_msgs.cpp
@@ -16,8 +16,7 @@
 
 #include "msg_converters/std_msgs.hpp"
 
-namespace autoware
-{
+
 namespace msgs
 {
 
@@ -146,4 +145,3 @@ void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float64 & o
 }
 
 }  // namespace msgs
-}  // namespace autoware

--- a/udp_driver/src/udp_driver.cpp
+++ b/udp_driver/src/udp_driver.cpp
@@ -20,8 +20,6 @@
 #include <string>
 #include <memory>
 
-namespace autoware
-{
 namespace drivers
 {
 
@@ -56,4 +54,3 @@ std::shared_ptr<UdpSocket> UdpDriver::receiver() const
 }
 
 }  // namespace drivers
-}  // namespace autoware

--- a/udp_driver/src/udp_socket.cpp
+++ b/udp_driver/src/udp_socket.cpp
@@ -20,8 +20,7 @@
 #include <utility>
 #include <string>
 
-namespace autoware
-{
+
 namespace drivers
 {
 
@@ -163,4 +162,3 @@ void UdpSocket::bind()
 }
 
 }  // namespace drivers
-}  // namespace autoware

--- a/udp_driver/test/test_io_context.cpp
+++ b/udp_driver/test/test_io_context.cpp
@@ -21,7 +21,7 @@
 
 #include "io_context/io_context.hpp"
 
-using autoware::drivers::IoContext;
+using drivers::IoContext;
 
 static constexpr size_t LENGTH = 10;
 

--- a/udp_driver/test/test_udp_data.cpp
+++ b/udp_driver/test/test_udp_data.cpp
@@ -18,8 +18,8 @@
 
 #include "udp_driver/udp_socket.hpp"
 
-using autoware::drivers::IoContext;
-using autoware::drivers::UdpSocket;
+using drivers::IoContext;
+using drivers::UdpSocket;
 
 const char ip[] = "127.0.0.1";
 constexpr uint16_t port = 8000;

--- a/udp_driver/test/test_udp_driver.cpp
+++ b/udp_driver/test/test_udp_driver.cpp
@@ -25,8 +25,8 @@
 #include "io_context/io_context.hpp"
 #include "udp_driver/udp_driver.hpp"
 
-using autoware::drivers::IoContext;
-using autoware::drivers::UdpDriver;
+using drivers::IoContext;
+using drivers::UdpDriver;
 
 const char ip[] = "127.0.0.1";
 constexpr uint16_t port = 8000;

--- a/udp_driver/test/test_udp_driver_node.cpp
+++ b/udp_driver/test/test_udp_driver_node.cpp
@@ -25,9 +25,9 @@
 
 #include "../examples/udp_driver_node.hpp"
 
-using autoware::drivers::IoContext;
-using autoware::drivers::UdpSocket;
-using autoware::drivers::UdpDriverNode;
+using drivers::IoContext;
+using drivers::UdpSocket;
+using drivers::UdpDriverNode;
 
 const char ip[] = "127.0.0.1";
 constexpr uint16_t port = 8000;

--- a/udp_driver/test/test_udp_socket.cpp
+++ b/udp_driver/test/test_udp_socket.cpp
@@ -18,8 +18,8 @@
 
 #include "udp_driver/udp_socket.hpp"
 
-using autoware::drivers::IoContext;
-using autoware::drivers::UdpSocket;
+using drivers::IoContext;
+using drivers::UdpSocket;
 
 const char ip[] = "127.0.0.1";
 constexpr uint16_t port = 8000;


### PR DESCRIPTION
one thing i wasnt sure about here was whether the `msgs` namespace should be within the top-level `drivers` namespace as well.