### PR TITLE
Enforce C++14. Do not duplicate compiler flags

### DIFF
--- a/io_context/CMakeLists.txt
+++ b/io_context/CMakeLists.txt
@@ -15,17 +15,16 @@
 # Maintained by LeoDrive, 2021
 
 cmake_minimum_required(VERSION 3.5)
-
 project(io_context)
 
-# Consider passing `-DCMAKE_BUILD_TYPE=Debug` option to cmake to export Debug symbols.
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 ## dependencies
 find_package(ament_cmake_auto REQUIRED)

--- a/serial_driver/CMakeLists.txt
+++ b/serial_driver/CMakeLists.txt
@@ -14,18 +14,23 @@
 #
 # Co-developed by Tier IV, Inc. and Apex.AI, Inc.
 cmake_minimum_required(VERSION 3.5)
-
 project(serial_driver)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 ## dependencies
 find_package(ament_cmake_auto REQUIRED)
-
 ament_auto_find_build_dependencies()
 
 find_package(asio_cmake_module REQUIRED)
 find_package(ASIO REQUIRED)
-
-include_directories(include ${ASIO_INCLUDE_DIRS})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto)

--- a/udp_driver/CMakeLists.txt
+++ b/udp_driver/CMakeLists.txt
@@ -26,15 +26,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# Consider passing `-DCMAKE_BUILD_TYPE=Debug` option to cmake to export Debug symbols.
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
-
 ## dependencies
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()


### PR DESCRIPTION
This PR contains the following changes:

- Enforces C++14 if no compiler standard is set
- Removes `${CMAKE_CXX_FLAGS}`, those flags are the same as the default build configurations in CMake and the way they are set is not cross-platform
- Removes building as `Release` by default. ROS 2 packages don't set their build type, the convention is that the buildfarm will do it.