### PR TITLE
Rename MutSocketBuffer to MutBuffer

### DIFF
--- a/io_context/include/io_context/common.hpp
+++ b/io_context/include/io_context/common.hpp
@@ -14,11 +14,11 @@
 
 // Developed by LeoDrive, 2021
 
-#ifndef MSG_CONVERTERS__COMMON_HPP_
-#define MSG_CONVERTERS__COMMON_HPP_
+#ifndef IO_CONTEXT__COMMON_HPP_
+#define IO_CONTEXT__COMMON_HPP_
 
 #include <asio.hpp>
 
-using MutSocketBuffer = asio::mutable_buffer;
+using MutBuffer = asio::mutable_buffer;
 
-#endif  // MSG_CONVERTERS__COMMON_HPP_
+#endif  // IO_CONTEXT__COMMON_HPP_

--- a/io_context/include/io_context/io_context.hpp
+++ b/io_context/include/io_context/io_context.hpp
@@ -21,7 +21,7 @@
 #include <vector>
 #include <utility>
 
-#include "asio.hpp"
+#include "io_context/common.hpp"
 
 namespace drivers
 {

--- a/io_context/include/msg_converters/std_msgs.hpp
+++ b/io_context/include/msg_converters/std_msgs.hpp
@@ -39,7 +39,7 @@
 #include <std_msgs/msg/float32.hpp>
 #include <std_msgs/msg/float64.hpp>
 
-#include "common.hpp"
+#include "io_context/common.hpp"
 
 namespace drivers
 {
@@ -50,51 +50,51 @@ namespace common
  * ROS2 Message to Raw Buffer Converters
  * std_msgs::msg::Int variant
  */
-void convertFromRos2Message(const std_msgs::msg::Int8::SharedPtr & in, MutSocketBuffer & out);
-void convertFromRos2Message(const std_msgs::msg::Int16::SharedPtr & in, MutSocketBuffer & out);
-void convertFromRos2Message(const std_msgs::msg::Int32::SharedPtr & in, MutSocketBuffer & out);
-void convertFromRos2Message(const std_msgs::msg::Int64::SharedPtr & in, MutSocketBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::Int8::SharedPtr & in, MutBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::Int16::SharedPtr & in, MutBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::Int32::SharedPtr & in, MutBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::Int64::SharedPtr & in, MutBuffer & out);
 
 /*
  * Raw Buffer to ROS2 Message Converters
  * std_msgs::msg::Int variant
  */
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Int8 & out);
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Int16 & out);
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Int32 & out);
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Int64 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Int8 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Int16 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Int32 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Int64 & out);
 
 /*
  * ROS2 Message to Raw Buffer Converters
  * std_msgs::msg::UInt variant
  */
-void convertFromRos2Message(const std_msgs::msg::UInt8::SharedPtr & in, MutSocketBuffer & out);
-void convertFromRos2Message(const std_msgs::msg::UInt16::SharedPtr & in, MutSocketBuffer & out);
-void convertFromRos2Message(const std_msgs::msg::UInt32::SharedPtr & in, MutSocketBuffer & out);
-void convertFromRos2Message(const std_msgs::msg::UInt64::SharedPtr & in, MutSocketBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::UInt8::SharedPtr & in, MutBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::UInt16::SharedPtr & in, MutBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::UInt32::SharedPtr & in, MutBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::UInt64::SharedPtr & in, MutBuffer & out);
 
 /*
  * Raw Buffer to ROS2 Message Converters
  * std_msgs::msg::UInt variant
  */
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::UInt8 & out);
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::UInt16 & out);
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::UInt32 & out);
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::UInt64 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::UInt8 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::UInt16 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::UInt32 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::UInt64 & out);
 
 /*
  * ROS2 Message to Raw Buffer Converters
  * std_msgs::msg::Float variant
  */
-void convertFromRos2Message(const std_msgs::msg::Float32::SharedPtr & in, MutSocketBuffer & out);
-void convertFromRos2Message(const std_msgs::msg::Float64::SharedPtr & in, MutSocketBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::Float32::SharedPtr & in, MutBuffer & out);
+void convertFromRos2Message(const std_msgs::msg::Float64::SharedPtr & in, MutBuffer & out);
 
 /*
  * Raw Buffer to ROS2 Message Converters
  * std_msgs::msg::Float variant
  */
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float32 & out);
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float64 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Float32 & out);
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Float64 & out);
 
 }  // namespace common
 }  // namespace drivers

--- a/io_context/src/msg_converters/std_msgs.cpp
+++ b/io_context/src/msg_converters/std_msgs.cpp
@@ -29,46 +29,46 @@ namespace common
  * ROS2 Message to Raw Buffer Converters
  * std_msgs::msg::Int variant
  */
-void convertFromRos2Message(const std_msgs::msg::Int8::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::Int8::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
-void convertFromRos2Message(const std_msgs::msg::Int16::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::Int16::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
-void convertFromRos2Message(const std_msgs::msg::Int32::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::Int32::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
-void convertFromRos2Message(const std_msgs::msg::Int64::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::Int64::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
 /*
  * Raw Buffer to ROS2 Message Converters
  * std_msgs::msg::Int variant
  */
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Int8 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Int8 & out)
 {
   out.data = *asio::buffer_cast<int8_t *>(in);
 }
 
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Int16 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Int16 & out)
 {
   out.data = *asio::buffer_cast<int16_t *>(in);
 }
 
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Int32 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Int32 & out)
 {
   out.data = *asio::buffer_cast<int32_t *>(in);
 }
 
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Int64 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Int64 & out)
 {
   out.data = *asio::buffer_cast<int64_t *>(in);
 }
@@ -77,46 +77,46 @@ void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Int64 & out
  * ROS2 Message to Raw Buffer Converters
  * std_msgs::msg::UInt variant
  */
-void convertFromRos2Message(const std_msgs::msg::UInt8::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::UInt8::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
-void convertFromRos2Message(const std_msgs::msg::UInt16::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::UInt16::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
-void convertFromRos2Message(const std_msgs::msg::UInt32::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::UInt32::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
-void convertFromRos2Message(const std_msgs::msg::UInt64::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::UInt64::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
 /*
  * Raw Buffer to ROS2 Message Converters
  * std_msgs::msg::UInt variant
  */
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::UInt8 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::UInt8 & out)
 {
   out.data = *asio::buffer_cast<int8_t *>(in);
 }
 
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::UInt16 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::UInt16 & out)
 {
   out.data = *asio::buffer_cast<int16_t *>(in);
 }
 
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::UInt32 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::UInt32 & out)
 {
   out.data = *asio::buffer_cast<int32_t *>(in);
 }
 
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::UInt64 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::UInt64 & out)
 {
   out.data = *asio::buffer_cast<int64_t *>(in);
 }
@@ -125,26 +125,26 @@ void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::UInt64 & ou
  * ROS2 Message to Raw Buffer Converters
  * std_msgs::msg::Float variant
  */
-void convertFromRos2Message(const std_msgs::msg::Float32::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::Float32::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
-void convertFromRos2Message(const std_msgs::msg::Float64::SharedPtr & in, MutSocketBuffer & out)
+void convertFromRos2Message(const std_msgs::msg::Float64::SharedPtr & in, MutBuffer & out)
 {
-  out = MutSocketBuffer(&in->data, sizeof(in->data));
+  out = MutBuffer(&in->data, sizeof(in->data));
 }
 
 /*
  * Raw Buffer to ROS2 Message Converters
  * std_msgs::msg::Float variant
  */
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float32 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Float32 & out)
 {
   out.data = *asio::buffer_cast<float_t *>(in);
 }
 
-void convertToRos2Message(const MutSocketBuffer & in, std_msgs::msg::Float64 & out)
+void convertToRos2Message(const MutBuffer & in, std_msgs::msg::Float64 & out)
 {
   out.data = *asio::buffer_cast<double_t *>(in);
 }

--- a/udp_driver/include/udp_driver/udp_receiver_node.hpp
+++ b/udp_driver/include/udp_driver/udp_receiver_node.hpp
@@ -75,7 +75,7 @@ public:
   LNI::CallbackReturn on_shutdown(const lc::State & state) override;
 
   /// \breif Callback for receiving a UDP datagram
-  void receiver_callback(const MutSocketBuffer & buffer);
+  void receiver_callback(const MutBuffer & buffer);
 
 private:
   void get_params();

--- a/udp_driver/include/udp_driver/udp_socket.hpp
+++ b/udp_driver/include/udp_driver/udp_socket.hpp
@@ -33,7 +33,7 @@ namespace drivers
 namespace udp_driver
 {
 
-using Functor = std::function<void (const MutSocketBuffer &)>;
+using Functor = std::function<void (const MutBuffer &)>;
 
 class UdpSocket
 {
@@ -55,17 +55,17 @@ public:
   /*
    * Blocking Send Operation
    */
-  std::size_t send(const MutSocketBuffer & buff);
+  std::size_t send(const MutBuffer & buff);
 
   /*
    * Blocking Receive Operation
    */
-  size_t receive(const MutSocketBuffer & buff);
+  size_t receive(const MutBuffer & buff);
 
   /*
    * NonBlocking Send Operation
    */
-  void asyncSend(const MutSocketBuffer & buff);
+  void asyncSend(const MutBuffer & buff);
 
   /*
    * NonBlocking Receive Operation

--- a/udp_driver/src/udp_receiver_node.cpp
+++ b/udp_driver/src/udp_receiver_node.cpp
@@ -127,7 +127,7 @@ void UdpReceiverNode::get_params()
   RCLCPP_INFO(get_logger(), "port: %i", m_port);
 }
 
-void UdpReceiverNode::receiver_callback(const MutSocketBuffer & buffer)
+void UdpReceiverNode::receiver_callback(const MutBuffer & buffer)
 {
   std_msgs::msg::Int32 out;
   drivers::common::convertToRos2Message(buffer, out);

--- a/udp_driver/src/udp_sender_node.cpp
+++ b/udp_driver/src/udp_sender_node.cpp
@@ -132,7 +132,7 @@ void UdpSenderNode::get_params()
 void UdpSenderNode::subscriber_callback(std_msgs::msg::Int32::SharedPtr msg)
 {
   if (this->get_current_state().id() == State::PRIMARY_STATE_ACTIVE) {
-    MutSocketBuffer out;
+    MutBuffer out;
     drivers::common::convertFromRos2Message(msg, out);
 
     m_udp_driver->sender()->asyncSend(out);

--- a/udp_driver/src/udp_socket.cpp
+++ b/udp_driver/src/udp_socket.cpp
@@ -44,7 +44,7 @@ UdpSocket::~UdpSocket()
   close();
 }
 
-std::size_t UdpSocket::send(const MutSocketBuffer & buff)
+std::size_t UdpSocket::send(const MutBuffer & buff)
 {
   try {
     return m_udp_socket.send_to(buff, m_endpoint);
@@ -54,7 +54,7 @@ std::size_t UdpSocket::send(const MutSocketBuffer & buff)
   }
 }
 
-size_t UdpSocket::receive(const MutSocketBuffer & buff)
+size_t UdpSocket::receive(const MutBuffer & buff)
 {
   asio::error_code error;
   asio::ip::udp::endpoint sender_endpoint;
@@ -72,7 +72,7 @@ size_t UdpSocket::receive(const MutSocketBuffer & buff)
   return len;
 }
 
-void UdpSocket::asyncSend(const MutSocketBuffer & buff)
+void UdpSocket::asyncSend(const MutBuffer & buff)
 {
   m_udp_socket.async_send_to(
     buff, m_endpoint,
@@ -115,7 +115,7 @@ void UdpSocket::asyncReceiveHandler(
   }
 
   if (bytes_transferred > 0 && m_func) {
-    m_func(MutSocketBuffer(m_recv_buffer.data(), bytes_transferred));
+    m_func(MutBuffer(m_recv_buffer.data(), bytes_transferred));
     m_udp_socket.async_receive_from(
       asio::buffer(m_recv_buffer, m_recv_buffer_size),
       m_endpoint,

--- a/udp_driver/test/test_udp_data.cpp
+++ b/udp_driver/test/test_udp_data.cpp
@@ -25,7 +25,7 @@ const char ip[] = "127.0.0.1";
 constexpr uint16_t port = 8000;
 static float PI = 3.14159265359;
 
-void handle_data(const MutSocketBuffer & buffer)
+void handle_data(const MutBuffer & buffer)
 {
   float received_PI = *reinterpret_cast<float *>(buffer.data());
   EXPECT_EQ(buffer.size(), sizeof(received_PI));
@@ -70,11 +70,11 @@ TEST(UdpDataTest, BlockingSendReceiveTest)
 
   receiver.bind();
 
-  std::size_t size = sender.send(MutSocketBuffer(reinterpret_cast<void *>(&PI), sizeof(PI)));
+  std::size_t size = sender.send(MutBuffer(reinterpret_cast<void *>(&PI), sizeof(PI)));
   EXPECT_EQ(size, sizeof(PI));
 
   float received_PI = 0.0f;
-  size = receiver.receive(MutSocketBuffer(&received_PI, sizeof(received_PI)));
+  size = receiver.receive(MutBuffer(&received_PI, sizeof(received_PI)));
   EXPECT_EQ(size, sizeof(received_PI));
   EXPECT_EQ(received_PI, PI);
 
@@ -100,7 +100,7 @@ TEST(UdpDataTest, NonBlockingSendReceiveTest)
   receiver.bind();
   receiver.asyncReceive(std::bind(handle_data, std::placeholders::_1));
 
-  MutSocketBuffer buffer(reinterpret_cast<void *>(&PI), sizeof(PI));
+  MutBuffer buffer(reinterpret_cast<void *>(&PI), sizeof(PI));
   sender.asyncSend(buffer);
   sender.asyncSend(buffer);
   sender.asyncSend(buffer);
@@ -129,7 +129,7 @@ TEST(UdpDataTest, BlockingSendNonBlockingReceiveTest)
   receiver.bind();
   receiver.asyncReceive(std::bind(handle_data, std::placeholders::_1));
 
-  std::size_t size = sender.send(MutSocketBuffer(reinterpret_cast<void *>(&PI), sizeof(PI)));
+  std::size_t size = sender.send(MutBuffer(reinterpret_cast<void *>(&PI), sizeof(PI)));
   EXPECT_EQ(size, sizeof(PI));
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));

--- a/udp_driver/test/test_udp_driver.cpp
+++ b/udp_driver/test/test_udp_driver.cpp
@@ -43,7 +43,7 @@ TEST(UdpDriverTest, NonBlockingSendReceiveTest)
   driver.receiver()->open();
   driver.receiver()->bind();
   driver.receiver()->asyncReceive(
-    [&](const MutSocketBuffer & buffer) {
+    [&](const MutBuffer & buffer) {
       sum += *reinterpret_cast<int32_t *>(buffer.data());
     });
 
@@ -51,7 +51,7 @@ TEST(UdpDriverTest, NonBlockingSendReceiveTest)
   EXPECT_EQ(driver.sender()->isOpen(), true);
 
   for (int val : {1, 2, 3, 4, 5}) {
-    driver.sender()->asyncSend(MutSocketBuffer(&val, sizeof(val)));
+    driver.sender()->asyncSend(MutBuffer(&val, sizeof(val)));
   }
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));

--- a/udp_driver/test/test_udp_driver_nodes.cpp
+++ b/udp_driver/test/test_udp_driver_nodes.cpp
@@ -51,7 +51,7 @@ TEST(UdpSenderNodeTest, RosMessageToRawUdpMessageSharedContext)
   EXPECT_EQ(receiver.isOpen(), true);
   receiver.bind();
   receiver.asyncReceive(
-    [&](const MutSocketBuffer & buffer) {
+    [&](const MutBuffer & buffer) {
       // Receive stream => 0 + 1 + 2+ 3 + 4 + 5 + 6 + 7 + 8 + 9 = 45
       sum += *reinterpret_cast<int32_t *>(buffer.data());
       if (sum == 45) {
@@ -169,7 +169,7 @@ TEST(UdpReceiverNodeTest, RawUdpMessageToRosMessageSharedContext)
     EXPECT_EQ(sender.isOpen(), true);
     int32_t count = 0;
     while (count <= 9) {
-      MutSocketBuffer buffer(reinterpret_cast<void *>(&count), sizeof(count));
+      MutBuffer buffer(reinterpret_cast<void *>(&count), sizeof(count));
       sender.asyncSend(buffer);
       count++;
     }


### PR DESCRIPTION
`MutSocketBuffer` indicates that the buffer can only be used for Sockets (such as with UDP) which is obviously not true. This renames `MutSocketBuffer` to `MutBuffer` and moves the `common.hpp` file to `io_context/include/io_context` because it is more generic than the `msg_converters` folder suggests.