### PR TITLE
Remove deprecated api from galactic

### DIFF
--- a/serial_driver/src/serial_bridge_node.cpp
+++ b/serial_driver/src/serial_bridge_node.cpp
@@ -126,21 +126,21 @@ void SerialBridgeNode::get_params()
   auto sb = StopBits::ONE;
 
   try {
-    m_device_name = declare_parameter("device_name").get<std::string>();
+    m_device_name = declare_parameter<std::string>("device_name");
   } catch (rclcpp::ParameterTypeException & ex) {
     RCLCPP_ERROR(get_logger(), "The device name provided was invalid");
     throw ex;
   }
 
   try {
-    baud_rate = declare_parameter("baud_rate").get<uint32_t>();
+    baud_rate = declare_parameter<int>("baud_rate");
   } catch (rclcpp::ParameterTypeException & ex) {
     RCLCPP_ERROR(get_logger(), "The baud_rate provided was invalid");
     throw ex;
   }
 
   try {
-    const auto fc_string = declare_parameter("flow_control").get<std::string>();
+    const auto fc_string = declare_parameter<std::string>("flow_control");
 
     if (fc_string == "none") {
       fc = FlowControl::NONE;
@@ -158,7 +158,7 @@ void SerialBridgeNode::get_params()
   }
 
   try {
-    const auto pt_string = declare_parameter("parity").get<std::string>();
+    const auto pt_string = declare_parameter<std::string>("parity");
 
     if (pt_string == "none") {
       pt = Parity::NONE;
@@ -176,7 +176,7 @@ void SerialBridgeNode::get_params()
   }
 
   try {
-    const auto sb_string = declare_parameter("stop_bits").get<std::string>();
+    const auto sb_string = declare_parameter<std::string>("stop_bits");
 
     if (sb_string == "1" || sb_string == "1.0") {
       sb = StopBits::ONE;

--- a/udp_driver/src/udp_receiver_node.cpp
+++ b/udp_driver/src/udp_receiver_node.cpp
@@ -111,14 +111,14 @@ LNI::CallbackReturn UdpReceiverNode::on_shutdown(const lc::State & state)
 void UdpReceiverNode::get_params()
 {
   try {
-    m_ip = declare_parameter("ip").get<std::string>();
+    m_ip = declare_parameter<std::string>("ip");
   } catch (rclcpp::ParameterTypeException & ex) {
     RCLCPP_ERROR(get_logger(), "The ip paramter provided was invalid");
     throw ex;
   }
 
   try {
-    m_port = declare_parameter("port").get<uint16_t>();
+    m_port = declare_parameter<int>("port");
   } catch (rclcpp::ParameterTypeException & ex) {
     RCLCPP_ERROR(get_logger(), "The port paramter provided was invalid");
     throw ex;

--- a/udp_driver/src/udp_sender_node.cpp
+++ b/udp_driver/src/udp_sender_node.cpp
@@ -113,14 +113,14 @@ LNI::CallbackReturn UdpSenderNode::on_shutdown(const lc::State & state)
 void UdpSenderNode::get_params()
 {
   try {
-    m_ip = declare_parameter("ip").get<std::string>();
+    m_ip = declare_parameter<std::string>("ip");
   } catch (rclcpp::ParameterTypeException & ex) {
     RCLCPP_ERROR(get_logger(), "The ip paramter provided was invalid");
     throw ex;
   }
 
   try {
-    m_port = declare_parameter("port").get<uint16_t>();
+    m_port = declare_parameter<int>("port");
   } catch (rclcpp::ParameterTypeException & ex) {
     RCLCPP_ERROR(get_logger(), "The port paramter provided was invalid");
     throw ex;


### PR DESCRIPTION
Remove deprecated api for `declare_parameter` from `galactic` to suppress build warnings.