### PR TITLE
Add a second constructor to avoid comparing size_t (unsigned int) and int

### DIFF
--- a/io_context/include/io_context/io_context.hpp
+++ b/io_context/include/io_context/io_context.hpp
@@ -59,7 +59,8 @@ struct thread_group
 class IoContext
 {
 public:
-  explicit IoContext(size_t threads_count = -1);
+  IoContext();
+  explicit IoContext(size_t threads_count);
   ~IoContext();
 
   IoContext(const IoContext &) = delete;

--- a/io_context/src/io_context.cpp
+++ b/io_context/src/io_context.cpp
@@ -26,15 +26,14 @@ namespace drivers
 namespace common
 {
 
+IoContext::IoContext()
+: IoContext(std::thread::hardware_concurrency()) {}
+
 IoContext::IoContext(size_t threads_count)
 : m_ios(new asio::io_service()),
   m_work(new asio::io_service::work(ios())),
   m_ios_thread_workers(new drivers::common::thread_group())
 {
-  if (threads_count == size_t(-1)) {
-    threads_count = std::thread::hardware_concurrency();
-  }
-
   for (size_t i = 0; i < threads_count; ++i) {
     m_ios_thread_workers->create_thread(
       [this]() {


### PR DESCRIPTION
The comparison between `thread_count` (`size_t`) and `-1` is causing issues when building `transport-drivers` as part of Autoware.Auto:

```
--- stderr: velodyne_nodes                                                                                                                                                              
In file included from /home/esteve/AutowareAuto/install/udp_driver/include/udp_driver/udp_driver.hpp:24,
                 from /home/esteve/AutowareAuto/src/drivers/velodyne_nodes/include/velodyne_nodes/velodyne_cloud_node.hpp:31,
                 from /home/esteve/AutowareAuto/src/drivers/velodyne_nodes/src/velodyne_cloud_node.cpp:25:
/home/esteve/AutowareAuto/install/io_context/include/io_context/io_context.hpp:62:45: error: unsigned conversion from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} changes value from ‘-1’ to ‘18446744073709551615’ [-Werror=sign-conversion]
   62 |   explicit IoContext(size_t threads_count = -1);
      |                                             ^~
/home/esteve/AutowareAuto/src/drivers/velodyne_nodes/src/velodyne_cloud_node.cpp: In instantiation of ‘autoware::drivers::velodyne_nodes::VelodyneCloudNode<SensorData>::VelodyneCloudNode(const string&, const rclcpp::NodeOptions&) [with SensorData = autoware::drivers::velodyne_driver::VLP16Data; std::string = std::__cxx11::basic_string<char>]’:
/home/esteve/AutowareAuto/src/drivers/velodyne_nodes/src/velodyne_cloud_node.cpp:167:16:   required from here
/home/esteve/AutowareAuto/install/io_context/include/io_context/io_context.hpp:62:45: error: unsigned conversion from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} changes value from ‘-1’ to ‘18446744073709551615’ [-Werror=sign-conversion]
/home/esteve/AutowareAuto/src/drivers/velodyne_nodes/src/velodyne_cloud_node.cpp: In instantiation of ‘autoware::drivers::velodyne_nodes::VelodyneCloudNode<SensorData>::VelodyneCloudNode(const string&, const rclcpp::NodeOptions&) [with SensorData = autoware::drivers::velodyne_driver::VLP32CData; std::string = std::__cxx11::basic_string<char>]’:
/home/esteve/AutowareAuto/src/drivers/velodyne_nodes/src/velodyne_cloud_node.cpp:168:16:   required from here
/home/esteve/AutowareAuto/install/io_context/include/io_context/io_context.hpp:62:45: error: unsigned conversion from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} changes value from ‘-1’ to ‘18446744073709551615’ [-Werror=sign-conversion]
/home/esteve/AutowareAuto/src/drivers/velodyne_nodes/src/velodyne_cloud_node.cpp: In instantiation of ‘autoware::drivers::velodyne_nodes::VelodyneCloudNode<SensorData>::VelodyneCloudNode(const string&, const rclcpp::NodeOptions&) [with SensorData = autoware::drivers::velodyne_driver::VLS128Data; std::string = std::__cxx11::basic_string<char>]’:
/home/esteve/AutowareAuto/src/drivers/velodyne_nodes/src/velodyne_cloud_node.cpp:169:16:   required from here
/home/esteve/AutowareAuto/install/io_context/include/io_context/io_context.hpp:62:45: error: unsigned conversion from ‘int’ to ‘size_t’ {aka ‘long unsigned int’} changes value from ‘-1’ to ‘18446744073709551615’ [-Werror=sign-conversion]
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/velodyne_cloud_node.dir/build.make:63: CMakeFiles/velodyne_cloud_node.dir/src/velodyne_cloud_node.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:188: CMakeFiles/velodyne_cloud_node.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
---
```