### PR TITLE
Check for closed port in destructor

### DIFF
--- a/serial_driver/src/serial_port.cpp
+++ b/serial_driver/src/serial_port.cpp
@@ -101,6 +101,7 @@ void SerialPort::async_receive_handler(
 {
   if (error) {
     RCLCPP_ERROR_STREAM(rclcpp::get_logger("SerialPort::async_receive_handler"), error.message());
+    m_serial_port.close();
     return;
   }
 

--- a/serial_driver/src/serial_port.cpp
+++ b/serial_driver/src/serial_port.cpp
@@ -40,7 +40,10 @@ SerialPort::SerialPort(
 
 SerialPort::~SerialPort()
 {
-  close();
+  if (open())
+  {
+    close();
+  }
 }
 
 size_t SerialPort::send(const std::vector<uint8_t> & buff)
@@ -138,7 +141,7 @@ void SerialPort::open()
 void SerialPort::close()
 {
   asio::error_code error;
-  m_serial_port.close(error);
+  close(error);
   if (error) {
     RCLCPP_ERROR_STREAM(rclcpp::get_logger("SerialPort::close"), error.message());
   }

--- a/serial_driver/src/serial_port.cpp
+++ b/serial_driver/src/serial_port.cpp
@@ -104,7 +104,7 @@ void SerialPort::async_receive_handler(
 {
   if (error) {
     RCLCPP_ERROR_STREAM(rclcpp::get_logger("SerialPort::async_receive_handler"), error.message());
-    m_serial_port.close();
+    close();
     return;
   }
 
@@ -141,7 +141,7 @@ void SerialPort::open()
 void SerialPort::close()
 {
   asio::error_code error;
-  close(error);
+  m_serial_port.close(error);
   if (error) {
     RCLCPP_ERROR_STREAM(rclcpp::get_logger("SerialPort::close"), error.message());
   }


### PR DESCRIPTION
As mentioned in https://github.com/ros-drivers/transport_drivers/issues/87, the fix to close the port in case of an error leads to the destructor trying to close it even though it has already been closed. As a simple solution, in the destructor we check, whether the port is still open or not.