### PR TITLE
Enable compilation on Windows by exporting all symbols of shared libraries (as is done by default in Linux and macOS)

### DIFF
--- a/io_context/CMakeLists.txt
+++ b/io_context/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 ## dependencies
 find_package(ament_cmake_auto REQUIRED)

--- a/serial_driver/CMakeLists.txt
+++ b/serial_driver/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 ## dependencies
 find_package(ament_cmake_auto REQUIRED)

--- a/udp_driver/CMakeLists.txt
+++ b/udp_driver/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 ## dependencies
 find_package(ament_cmake_auto REQUIRED)


### PR DESCRIPTION
This package compiles several shared libraries, but does not expose any symbol on Windows, so if the CMake project is compiled on Windows, no import library `.lib` is actually generated.

On Linux and macOS, everything compiles fine as by default all the symbols are visible. We can achieve exactly the same behavior in Windows by setting to `ON` the [`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html) CMake variable, so this PR sets the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` variable to `ON`, to ensure that the compilation works fine on Windows.