### PR TITLE
asio::ip::{address::from_string -> make_address}

### DIFF
--- a/udp_driver/src/udp_socket.cpp
+++ b/udp_driver/src/udp_socket.cpp
@@ -38,15 +38,15 @@ UdpSocket::UdpSocket(
   const uint16_t host_port)
 : m_ctx(ctx),
   m_udp_socket(ctx.ios()),
-  m_remote_endpoint(address::from_string(remote_ip), remote_port),
-  m_host_endpoint(address::from_string(host_ip), host_port)
+  m_remote_endpoint(asio::ip::make_address(remote_ip), remote_port),
+  m_host_endpoint(asio::ip::make_address(host_ip), host_port)
 {
   m_remote_endpoint = remote_ip.empty() ?
     udp::endpoint{udp::v4(), remote_port} :
-  udp::endpoint{address::from_string(remote_ip), remote_port};
+  udp::endpoint{asio::ip::make_address(remote_ip), remote_port};
   m_host_endpoint = host_ip.empty() ?
     udp::endpoint{udp::v4(), host_port} :
-  udp::endpoint{address::from_string(host_ip), host_port};
+  udp::endpoint{asio::ip::make_address(host_ip), host_port};
   m_recv_buffer.resize(m_recv_buffer_size);
 }
 


### PR DESCRIPTION
Hi again,

Here is another fix for asio 1.36, this time for udp_driver.

`from_string` has been deprecated for at least 9 years (ref blame https://github.com/boostorg/asio/blame/b60e92b13ef68dfbb9af180d76eae41d22e19356/include/boost/asio/ip/address.hpp), and removed in https://github.com/boostorg/asio/commit/c0d1cfce7767599c4cf00df36f8017a1073339ae